### PR TITLE
Use "current" user's $APPDATA for Namecoin Core config instead of "all" users'.

### DIFF
--- a/ncdns.nsi
+++ b/ncdns.nsi
@@ -407,6 +407,9 @@ Function NamecoinCoreConfig
 
   DetailPrint "Configuring Namecoin Core..."
 
+  # We need the current user's $APPDATA for configuring Namecoin Core.
+  SetShellVarContext current
+
   # We have to set 'server=1' in namecoin.conf. We can use cookies to get the
   # rest, so that's all we need.
   #
@@ -424,6 +427,7 @@ Function NamecoinCoreConfig
   WriteRegStr HKCU "Software\Namecoin\Namecoin-Qt" "strDataDir" $NamecoinCoreDataDir
 
 haveDataDir:
+  DetailPrint 'Creating directory "$NamecoinCoreDataDir"...'
   CreateDirectory $NamecoinCoreDataDir
 
   # Configure cookie directory.
@@ -443,6 +447,9 @@ haveDataDir:
   nsExec::ExecToLog '$PLUGINSDIR\confignamecoinconf.cmd'
   Delete $PLUGINSDIR\confignamecoinconf.ps1
   Delete $PLUGINSDIR\confignamecoinconf.cmd
+
+  # Restore SetShellVarContext
+  SetShellVarContext all
 FunctionEnd
 
 


### PR DESCRIPTION
ncdns-nsis was using the "All Users" value of `$APPDATA`, which caused Namecoin Core's data directory to be placed in `C:\ProgramData\`.  This then caused Namecoin Core to crash on startup with a permission error, because average users don't have write permissions for that directory.  This PR fixes the issue.