### PR TITLE
Update dnssec-keygen to 9.13.2 and Dnssec-Trigger to 0.17.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(ARTIFACTS)/ncdns.exe: $(ARTIFACTS)/$(NCDNS_ARCFN)
 
 ### DNSSEC-KEYGEN
 ##############################################################################
-BINDV=9.12.1
+BINDV=9.13.2
 $(ARTIFACTS)/BIND$(BINDV).$(BINDARCH).zip:
 	wget -O "$@" "https://ftp.isc.org/isc/bind/$(BINDV)/BIND$(BINDV).$(BINDARCH).zip"
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(ARTIFACTS)/dnssec-keygen.exe: $(ARTIFACTS)/BIND$(BINDV).$(BINDARCH).zip
 
 ### DNSSEC-TRIGGER
 ##############################################################################
-DNSSEC_TRIGGER_VER=0.15
+DNSSEC_TRIGGER_VER=0.17
 DNSSEC_TRIGGER_FN=dnssec_trigger_setup_$(DNSSEC_TRIGGER_VER).exe
 DNSSEC_TRIGGER_URL=https://www.nlnetlabs.nl/downloads/dnssec-trigger/
 #DNSSEC_TRIGGER_URL=https://www.nlnetlabs.nl/~wouter/


### PR DESCRIPTION
Note that I haven't yet tested this PR in any way.  Test reports are welcome, although I think it's unlikely that these dependency updates will break anything.