### PR TITLE
Cirrus: Update certinject URL

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,7 +41,7 @@ task:
     - mkdir -p build64/artifacts/
     - cd build64/artifacts/
     - curl -o bitcoinj-daemon.jar https://www.namecoin.org/files/ConsensusJ-Namecoin/0.3.2.1/namecoinj-daemon-0.3.2-SNAPSHOT.jar
-    - curl -o certinject--windows_amd64.tar.gz https://api.cirrus-ci.com/v1/artifact/github/namecoin/certinject/Artifact%20Upload/binaries/dist/certinject--windows_amd64.tar.gz
+    - curl -o certinject--windows_amd64.tar.gz https://api.cirrus-ci.com/v1/artifact/github/namecoin/certinject/Cross-Compile%20Go%20latest/binaries/dist/certinject--windows_amd64.tar.gz
     - tar -xaf certinject--windows_amd64.tar.gz
     - mv certinject--windows_amd64/bin/certinject.exe ./
     - rm -rf certinject--windows_amd64/


### PR DESCRIPTION
certinject changed its artifact URL in https://github.com/namecoin/certinject/pull/59