### PR TITLE
Fix generate_nmc_cert dependency

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
   fetch_script:
     # TODO: remove this, download a binary of qexe instead
     - go get -d -v github.com/miekg/exdns/q
-    # TODO: remove this, download ConsensusJ-Namecoin, certinject, and Encaya like we do everything else.
+    # TODO: remove this, download ConsensusJ-Namecoin, certinject, Encaya, and generate_nmc_cert like we do everything else.
     - mkdir -p build64/artifacts/
     - cd build64/artifacts/
     - curl -o bitcoinj-daemon.jar https://www.namecoin.org/files/ConsensusJ-Namecoin/0.3.2.1/namecoinj-daemon-0.3.2-SNAPSHOT.jar
@@ -49,6 +49,10 @@ task:
     - tar -xaf encaya--windows_amd64.tar.gz
     - mv encaya--windows_amd64/bin/*.exe ./
     - rm -rf encaya--windows_amd64/
+    - curl -o generate_nmc_cert--windows_amd64.tar.gz https://api.cirrus-ci.com/v1/artifact/github/namecoin/generate_nmc_cert/Cross-Compile%20Go%20latest/binaries/dist/generate_nmc_cert--windows_amd64.tar.gz
+    - tar -xaf generate_nmc_cert--windows_amd64.tar.gz
+    - mv generate_nmc_cert--windows_amd64/bin/*.exe ./
+    - rm -rf generate_nmc_cert--windows_amd64/
     - cd ../../
   build_script:
     # TODO: check for NSIS warnings

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Put the following files in `artifacts/`:
       `BIND{version}.xp.zip`.
   - dnssec_trigger_setup.exe
   - namecoin-win32-setup-unsigned.exe / namecoin-win64-setup-unsigned.exe
-
-  - Optionally, add `ncdt.exe` and `ncdumpzone.exe` from ncdns.
-  - `generate_nmc_cert.exe` and `q.exe` will also be copied if they are present.
+  - `ncdt.exe` and `ncdumpzone.exe` from ncdns
+  - `generate_nmc_cert.exe`
+  - `q.exe` from miekg/exdns
 
 Build flags:
 

--- a/ncdns.nsi
+++ b/ncdns.nsi
@@ -936,10 +936,10 @@ Function Files
 # makensis version I'm using. Bleh.
 #!endif
 
-  File /nonfatal /oname=$INSTDIR\bin\ncdt.exe ${ARTIFACTS}\ncdt.exe
-  File /nonfatal /oname=$INSTDIR\bin\ncdumpzone.exe ${ARTIFACTS}\ncdumpzone.exe
-  File /nonfatal /oname=$INSTDIR\bin\generate_nmc_cert.exe ${ARTIFACTS}\generate_nmc_cert.exe
-  File /nonfatal /oname=$INSTDIR\bin\q.exe ${ARTIFACTS}\q.exe
+  File /oname=$INSTDIR\bin\ncdt.exe ${ARTIFACTS}\ncdt.exe
+  File /oname=$INSTDIR\bin\ncdumpzone.exe ${ARTIFACTS}\ncdumpzone.exe
+  File /oname=$INSTDIR\bin\generate_nmc_cert.exe ${ARTIFACTS}\generate_nmc_cert.exe
+  File /oname=$INSTDIR\bin\q.exe ${ARTIFACTS}\q.exe
 FunctionEnd
 
 Function FilesConfig


### PR DESCRIPTION
It's no longer part of ncdns.