### PR TITLE
Configure Electrum-NMC

### DIFF
--- a/configelectrum.ps1
+++ b/configelectrum.ps1
@@ -1,0 +1,29 @@
+$InstDir = Get-ItemProperty -Path HKCU:\Software\Electrum-NMC | Select-Object -ExpandProperty '(Default)'
+
+$ElectrumExeSearch = Get-ChildItem "$InstDir" -Recurse -Force -Include electrum-nmc-*.exe
+
+$ElectrumExeName = $ElectrumExeSearch[0].Name
+
+$ElectrumExe = "$InstDir\$ElectrumExeName"
+
+& "$ElectrumExe" setconfig rpcport 8336 | Out-Null
+Start-Sleep -Seconds 5
+
+# Generate random 32-byte hex password
+$RpcUser = -join ( 1..64 | ForEach-Object { (48..57) + (65..70) | Get-Random | % {[char]$_} } )
+$RpcPassword = -join ( 1..64 | ForEach-Object { (48..57) + (65..70) | Get-Random | % {[char]$_} } )
+
+& "$ElectrumExe" setconfig rpcuser "$RpcUser" | Out-Null
+Start-Sleep -Seconds 5
+
+& "$ElectrumExe" setconfig rpcpassword "$RpcPassword" | Out-Null
+Start-Sleep -Seconds 5
+
+echo '[ncdns]'
+echo ''
+echo 'namecoinrpcaddress="127.0.0.1:8336"'
+echo "namecoinrpcusername=`"$RpcUser`""
+echo "namecoinrpcpassword=`"$RpcPassword`""
+# Electrum-NMC can take a few seconds to run name_show; the default 1500 ms
+# timeout isn't long enough.
+echo 'namecoinrpctimeout="5000"'

--- a/namecoin-dialog.nsdinc
+++ b/namecoin-dialog.nsdinc
@@ -3,6 +3,7 @@ Var NamecoinDialog
 Var NamecoinDialog_Status
 Var NamecoinDialog_Core
 Var NamecoinDialog_ConsensusJ
+Var NamecoinDialog_Electrum
 Var NamecoinDialog_Manual
 
 Function NamecoinDialog_CreateSkeleton
@@ -20,17 +21,21 @@ Function NamecoinDialog_CreateSkeleton
   Pop $NamecoinDialog_Status
 
   # Namecoin Core RadioButton
-  ${NSD_CreateRadioButton} 10u 22.5u -10u 15u "NAMECOIN_NODE_YES"
+  ${NSD_CreateRadioButton} 10u 22.5u -10u 15u "NAMECOIN_NODE_CORE"
   Pop $NamecoinDialog_Core
   ${NSD_AddStyle} $NamecoinDialog_Core ${WS_GROUP}
   ${NSD_Check} $NamecoinDialog_Core
 
   # ConsensusJ RadioButton
-  ${NSD_CreateRadioButton} 10u 37.5u -10u 15u "NAMECOIN_NODE_SPV"
+  ${NSD_CreateRadioButton} 10u 37.5u -10u 15u "NAMECOIN_NODE_CONSENSUSJ"
   Pop $NamecoinDialog_ConsensusJ
 
+  # Electrum-NMC RadioButton
+  ${NSD_CreateRadioButton} 10u 52.5u -10u 15u "NAMECOIN_NODE_ELECTRUM"
+  Pop $NamecoinDialog_Electrum
+
   # Manual RadioButton
-  ${NSD_CreateRadioButton} 10u 52.5u -10u 15u "NAMECOIN_NODE_NO"
+  ${NSD_CreateRadioButton} 10u 67.5u -10u 15u "NAMECOIN_NODE_NO"
   Pop $NamecoinDialog_Manual
 
 FunctionEnd

--- a/ncdns.nsi
+++ b/ncdns.nsi
@@ -197,6 +197,16 @@ Function .onInit
 
   Call DetectETLD
 
+  # Default components
+  Push ${BST_UNCHECKED}
+  Pop $SkipNamecoinCore
+  Push ${BST_UNCHECKED}
+  Pop $UseSPV
+  Push ${BST_UNCHECKED}
+  Pop $UseElectrumNMC
+  Push ${BST_UNCHECKED}
+  Pop $SkipUnbound
+
   Call FailIfBindRequirementsNotMet
 FunctionEnd
 


### PR DESCRIPTION
Detects existing Electrum-NMC installation, and offers to configure it instead of Namecoin Core if it's there.  Doesn't chainload the Electrum-NMC installer.

Refs https://github.com/namecoin/ncdns-nsis/issues/86

Fixes https://github.com/namecoin/ncdns-nsis/issues/63