### PR TITLE
Use latest Namecoin Core release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,6 +38,9 @@ task:
     # TODO: remove this, download ConsensusJ-Namecoin, certinject, Encaya, and generate_nmc_cert like we do everything else.
     - mkdir -p build64/artifacts/
     - cd build64/artifacts/
+    # Namecoin Core
+    - LATEST_NAMECOIN_CORE_VERSION=$(curl https://www.namecoin.org/download/ | grep --only-matching -E 'namecoin-core-[0-9\.]+' | head --lines=1 | grep --only-matching -E '[0-9\.]+')
+    - curl -o namecoin-win64-setup-unsigned.exe https://www.namecoin.org/files/namecoin-core/namecoin-core-$LATEST_NAMECOIN_CORE_VERSION/namecoin-nc$LATEST_NAMECOIN_CORE_VERSION-win64-setup-unsigned.exe
     # ConsensusJ
     - curl -o bitcoinj-daemon.jar https://www.namecoin.org/files/ConsensusJ-Namecoin/0.3.2.1/namecoinj-daemon-0.3.2-SNAPSHOT.jar
     # Electrum-NMC

--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,7 @@ $(ARTIFACTS)/$(DNSSEC_TRIGGER_FN):
 
 ### NAMECOIN
 ##############################################################################
-NAMECOIN_VER=0.13.99
-NAMECOIN_VER_TAG=-name-tab-beta1-notreproduced
-NAMECOIN_FN=namecoin-$(NAMECOIN_VER)-$(NCARCH)-setup-unsigned.exe
-
-$(ARTIFACTS)/$(NAMECOIN_FN):
-	wget -O "$@" "https://namecoin.org/files/namecoin-core-$(NAMECOIN_VER)$(NAMECOIN_VER_TAG)/$(NAMECOIN_FN)"
+NAMECOIN_FN=namecoin-win64-setup-unsigned.exe
 
 
 ### ELECTRUM-NMC
@@ -103,7 +98,7 @@ ELECTRUM_NMC_FN=electrum-nmc-setup.exe
 
 ### INSTALLER
 ##############################################################################
-$(OUTFN): ncdns.nsi $(NEUTRAL_ARTIFACTS)/ncdns.conf $(ARTIFACTS)/$(DNSSEC_TRIGGER_FN) $(ARTIFACTS)/$(NAMECOIN_FN) $(ARTIFACTS)/q.exe
+$(OUTFN): ncdns.nsi $(NEUTRAL_ARTIFACTS)/ncdns.conf $(ARTIFACTS)/$(DNSSEC_TRIGGER_FN) $(ARTIFACTS)/q.exe
 	@mkdir -p "$(BUILD)/bin"
 	$(MAKENSIS) $(NSISFLAGS) -DPOSIX_BUILD=1 -DNCDNS_PRODVER=$(NCDNS_PRODVER_W) \
 		$(_NCDNS_64BIT) $(_NO_NAMECOIN_CORE) $(_NO_ELECTRUM_NMC) $(_NO_DNSSEC_TRIGGER) $(_NCDNS_LOGGING) \


### PR DESCRIPTION
0.13.99 is nearly useless for name lookups without manual peer discovery, and the name management GUI is almost done.