### PR TITLE
Remove Layer-1 TLS

### DIFF
--- a/ncdns.nsi
+++ b/ncdns.nsi
@@ -240,7 +240,9 @@ win7okay:
   Pop $UseUnbound
 
   # Default components: TLS
-  Push ${BST_CHECKED}
+  # CertInject temporarily disabled
+  #Push ${BST_CHECKED}
+  Push ${BST_UNCHECKED}
   Pop $CryptoAPIInjectionEnabled
   Push ${BST_CHECKED}
   Pop $CryptoAPIEncayaEnabled
@@ -664,14 +666,16 @@ Function TLSPositiveDialogCreate
   Call TLSPositiveDialog_CreateSkeleton
 
   # Restore state
-  ${NSD_SetState} $TLSPositiveDialog_CryptoAPILayer1 $CryptoAPIInjectionEnabled
+  # CertInject temporarily disabled
+  #${NSD_SetState} $TLSPositiveDialog_CryptoAPILayer1 $CryptoAPIInjectionEnabled
   ${NSD_SetState} $TLSPositiveDialog_CryptoAPILayer2 $CryptoAPIEncayaEnabled
 
   nsDialogs::Show
 FunctionEnd
 
 Function TLSPositiveDialogLeave
-  ${NSD_GetState} $TLSPositiveDialog_CryptoAPILayer1 $CryptoAPIInjectionEnabled
+  # CertInject temporarily disabled
+  #${NSD_GetState} $TLSPositiveDialog_CryptoAPILayer1 $CryptoAPIInjectionEnabled
   ${NSD_GetState} $TLSPositiveDialog_CryptoAPILayer2 $CryptoAPIEncayaEnabled
 FunctionEnd
 

--- a/tls-positive-dialog.nsdinc
+++ b/tls-positive-dialog.nsdinc
@@ -1,6 +1,5 @@
 Var TLSPositiveDialog
 
-Var TLSPositiveDialog_CryptoAPILayer1
 Var TLSPositiveDialog_CryptoAPILayer2
 
 Function TLSPositiveDialog_CreateSkeleton
@@ -13,12 +12,8 @@ Function TLSPositiveDialog_CreateSkeleton
   ${EndIf}
   !insertmacro MUI_HEADER_TEXT "Censorship-Resistant TLS" "Enable Namecoin TLS connections without certificate errors."
 
-  # CryptoAPI Layer 1 CheckBox
-  ${NSD_CreateCheckBox} 0u 0u 100% 50% "CryptoAPI Layer 1: Works for web browsers that use Windows for certificate verification (i.e. most non-Mozilla browsers).  Requires granting ncdns run-time permission to modify Windows's root certificate authority list.  If an attacker were able to exploit ncdns, they might be able to wiretap or tamper with your Internet traffic (both Namecoin and non-Namecoin websites).  Cannot be shared with other devices.  Deprecated, but might be required for websites who haven't upgraded to Layer 2."
-  Pop $TLSPositiveDialog_CryptoAPILayer1
-
   # CryptoAPI Layer 2 CheckBox
-  ${NSD_CreateCheckBox} 0u 50% 100% 50% "CryptoAPI Layer 2: Works for arbitrary applications that use Windows for certificate verification.  Only grants ncdns run-time access to a CA constrained to the Namecoin TLD.  If an attacker were able to exploit ncdns, non-Namecoin Internet traffic would be unaffected.  Some already-insecure 3rd-party software might behave insecurely in the presence of ncdns (not an ncdns bug).  Can be shared with other devices."
+  ${NSD_CreateCheckBox} 0u 0u 100% 100% "CryptoAPI: Works for arbitrary applications that use Windows for certificate verification (e.g. most non-Mozilla browsers).  Only grants ncdns run-time access to a CA constrained to the Namecoin TLD.  If an attacker were able to exploit ncdns, non-Namecoin Internet traffic would be unaffected.  Some already-insecure 3rd-party software might behave insecurely in the presence of ncdns (not an ncdns bug).  Can be shared with other devices."
   Pop $TLSPositiveDialog_CryptoAPILayer2
 
 FunctionEnd


### PR DESCRIPTION
The implementation code is left intact because we will repurpose it for intermediate CA certinject.

Fixes https://github.com/namecoin/ncdns-nsis/issues/106